### PR TITLE
Remove cancel button in progress view

### DIFF
--- a/Allihoopa.podspec
+++ b/Allihoopa.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "Allihoopa"
-  s.version      = "1.3.0"
+  s.version      = "1.3.1"
   s.summary      = "SDK to drop and import pieces to and from Allihoopa."
 
   # This description is used to generate tags and improve search results.

--- a/Allihoopa/Drop/Base.lproj/DropFlow.storyboard
+++ b/Allihoopa/Drop/Base.lproj/DropFlow.storyboard
@@ -69,22 +69,14 @@
                             <constraint firstItem="ksV-5J-Lps" firstAttribute="top" secondItem="qAg-kq-XAh" secondAttribute="bottom" constant="20" id="wpA-nD-jAC"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="2W8-Hk-PTU">
-                        <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="d3B-e7-mlK">
-                            <connections>
-                                <segue destination="wg3-eg-0AR" kind="unwind" unwindAction="cancelDropUnwind:" id="fn5-Kd-0Xm"/>
-                            </connections>
-                        </barButtonItem>
-                    </navigationItem>
                     <connections>
                         <outlet property="warningContainer" destination="qAg-kq-XAh" id="st1-yt-Q2n"/>
                         <segue destination="BcL-h0-hKF" kind="show" identifier="dropProgressDone" id="NSC-aC-6I1"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8k7-lX-QZO" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <exit id="wg3-eg-0AR" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="1682" y="177"/>
+            <point key="canvasLocation" x="1674" y="276"/>
         </scene>
         <!--Drop Error View Controller-->
         <scene sceneID="c69-AV-VD2">

--- a/Allihoopa/Drop/DropProgressViewController.m
+++ b/Allihoopa/Drop/DropProgressViewController.m
@@ -19,6 +19,8 @@
 
 	_warningContainer.layer.borderColor = [UIColor colorWithWhite:0 alpha:0.09f].CGColor;
 	_warningContainer.layer.borderWidth = 1;
+
+	self.navigationItem.hidesBackButton = YES;
 }
 
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(__unused id)sender {

--- a/Allihoopa/Drop/ja.lproj/DropFlow.storyboard
+++ b/Allihoopa/Drop/ja.lproj/DropFlow.storyboard
@@ -71,20 +71,12 @@
                             <constraint firstItem="ksV-5J-Lps" firstAttribute="top" secondItem="qAg-kq-XAh" secondAttribute="bottom" constant="20" id="wpA-nD-jAC"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="2W8-Hk-PTU">
-                        <barButtonItem key="leftBarButtonItem" title="キャンセル" id="d3B-e7-mlK">
-                            <connections>
-                                <segue destination="wg3-eg-0AR" kind="unwind" unwindAction="cancelDropUnwind:" id="fn5-Kd-0Xm"/>
-                            </connections>
-                        </barButtonItem>
-                    </navigationItem>
                     <connections>
                         <outlet property="warningContainer" destination="qAg-kq-XAh" id="st1-yt-Q2n"/>
                         <segue destination="BcL-h0-hKF" kind="show" identifier="dropProgressDone" id="NSC-aC-6I1"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8k7-lX-QZO" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <exit id="wg3-eg-0AR" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="2093" y="175"/>
         </scene>

--- a/AppledocSettings.plist
+++ b/AppledocSettings.plist
@@ -24,7 +24,7 @@
 	<key>--project-name</key>
 	<string>Allihoopa</string>
 	<key>--project-version</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>--keep-undocumented-objects</key>
 	<true/>
 	<key>--keep-undocumented-members</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 Change log
 ==========
 
+## [1.3.1] — 2017-06-02
+
+Removed the Cancel button from the Drop progress view.
+
+### Added
+
+* Support for uploading and fetching piece attachments
+
 ## [1.3.0] — 2017-05-29
 
 Updated AllihoopaCore dependency to 1.2.0.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you use [CocoaPods], you can simply add this SDK to your `Podfile`:
 
 ```ruby
 target 'TargetName' do
-  pod 'Allihoopa', '~> 1.3.0'
+  pod 'Allihoopa', '~> 1.3.1'
 end
 ```
 
@@ -31,7 +31,7 @@ pod install
 If you use [Carthage], you instead add this SDK to your `Cartfile`:
 
 ```
-github "Allihoopa/Allihoopa-iOS" ~> 1.3.0
+github "Allihoopa/Allihoopa-iOS" ~> 1.3.1
 ```
 
 After this, you run `carthage update` to build the framework, and then drag the


### PR DESCRIPTION
This PR removes the "Cancel" button in the progress view that is shown between pressing the "DROP" button and seeing the finished dropped piece.