### PR TITLE
Sets indentation to tabs

### DIFF
--- a/Allihoopa.xcodeproj/project.pbxproj
+++ b/Allihoopa.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 				FA5FD38B1D90180F0010E978 /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		FA5FD38B1D90180F0010E978 /* Products */ = {
 			isa = PBXGroup;

--- a/SDKExample/SDKExample.xcodeproj/project.pbxproj
+++ b/SDKExample/SDKExample.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 				FA1314031DE5C90500378FDE /* Frameworks */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		FAF525D11D9531E7002CE6BF /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
Sets indentation to tabs in the Example project and the SDK. This is
needed because spaces is the default in Xcode, and we can't force 3rd
party contributors to update their IDE settings.